### PR TITLE
Refactor Classification into functional component

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "devDependencies": {
+    "react-test-renderer": "^16.8.4"
+  }
 }

--- a/src/__tests__/unit/__snapshots__/classification.spec.js.snap
+++ b/src/__tests__/unit/__snapshots__/classification.spec.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Classification /> renders an <img /> component 1`] = `
+<img
+  alt=""
+  src="gallery2.jpeg"
+/>
+`;
+
+exports[`<Classification /> renders correctly 1`] = `
+<img
+  alt=""
+  src="gallery2.jpeg"
+/>
+`;

--- a/src/__tests__/unit/__snapshots__/classification.spec.js.snap
+++ b/src/__tests__/unit/__snapshots__/classification.spec.js.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Classification /> renders an <img /> component 1`] = `
-<img
-  alt=""
-  src="gallery2.jpeg"
-/>
-`;
-
 exports[`<Classification /> renders correctly 1`] = `
 <img
   alt=""

--- a/src/__tests__/unit/classification.spec.js
+++ b/src/__tests__/unit/classification.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Classification from '../../components/Classification';
+
+describe('<Classification />', () => {
+  it('renders correctly', () => {
+    const tree = renderer
+      .create(<Classification />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/Classification.js
+++ b/src/components/Classification.js
@@ -1,11 +1,7 @@
-import React, { Component } from "react";
+import React from "react";
 
-class Classification extends Component {
-  render() {
-    return (
-      <img src={require('./../Images/gallery2.jpeg')} alt=""/>
-    );
-  }
-}
+const classification = () => (
+  <img src={require('./../Images/gallery2.jpeg')} alt=""/>
+);
 
-export default Classification;
+export default classification;


### PR DESCRIPTION
How about dropping the `Component` dependency and use it in a functional form? Should make it easier to test afterwards :)